### PR TITLE
Update application.js

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -29,5 +29,4 @@ function findTimeZone() {
   }
 }
 
-const timezone = findTimeZone()
-setCookie("timezone", timezone.name())
+setCookie("timezone", findTimeZone())


### PR DESCRIPTION
`setCookie("timezone", timezone.name())` returns an error `Uncaught TypeError: findTimeZone(...).name is not a function` because `findTimeZone()` already returns `name()`